### PR TITLE
remove unused bin entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
   "bugs": {
     "url": "https://github.com/spatialillusions/MilSymbol/issues"
   },
-  "homepage": "https://github.com/spatialillusions/MilSymbol",
-  "bin": {
-    "milsymbol": "milsymbol.js"
-  }
+  "homepage": "https://github.com/spatialillusions/MilSymbol"
 }


### PR DESCRIPTION
So, it seems the bin entry in package.json cause the error in #20 , this is not a cli so there is no need of it.