### PR TITLE
remove unused bin entry in package.json (based on lastest changes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
   "bugs": {
     "url": "https://github.com/spatialillusions/milsymbol/issues"
   },
-  "homepage": "https://github.com/spatialillusions/milsymbol",
-  "bin": {
-    "milsymbol": "milsymbol.js"
-  }
+  "homepage": "https://github.com/spatialillusions/milsymbol"
 }


### PR DESCRIPTION
So, it seems the bin entry in package.json cause the error in #20 , this is not a cli so there is no need of it.