### PR TITLE
fixed bug in getMarker when object prototype is extended

### DIFF
--- a/dist/milsymbol.js
+++ b/dist/milsymbol.js
@@ -2031,6 +2031,7 @@ var MS = new function(){
 			this.bbox = MS.bbox();
 			//Processing all parts of the marker, adding them to the drawinstruction and updating the boundingbox
 			for (var i in MS._markerParts){
+				if (!MS._markerParts.hasOwnProperty(i)) continue;
 				var m = MS._markerParts[i].call(this);
 				if (!m.pre) continue;
 				if(m.pre.length)this.drawInstructions.unshift(m.pre);


### PR DESCRIPTION
This fixes a bug discovered when using milsymbol alongside other frameworks that do mean things like: `Object.prototype.extra = {}`