### PR TITLE
Add support for loading milsymbol as a CommonJS module

### DIFF
--- a/dist/milsymbol.js
+++ b/dist/milsymbol.js
@@ -6606,3 +6606,8 @@ MS._Path2D = function(ctx, d){
 		}
 	}
 };
+
+// Add support for CommonJS and Browserify/webpack etc.
+if (typeof module === 'object' && typeof module.exports === 'object') {
+	module.exports = MS;
+}


### PR DESCRIPTION
Exports the MS class. This allows you to use milsymbol with tools like browserify and webpack.