### PR TITLE
Fix ES6 tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,20 @@
 {
   "name": "milsymbol",
   "version": "1.3.3",
-  "description":
-    "Milsymbol.js is a small library in pure javascript that creates symbols according to MIL-STD-2525 and APP6.",
+  "description": "Milsymbol.js is a small library in pure javascript that creates symbols according to MIL-STD-2525 and APP6.",
   "main": "dist/milsymbol.js",
   "directories": {
     "doc": "docs",
     "example": "examples"
   },
+  "@std/esm": "cjs",
   "scripts": {
     "lint": "eslint src test --fix",
     "prebuild": "npm run lint && npm test",
     "build": "npm run bundle && npm run minify",
     "bundle": "rollup -c",
-    "minify":
-      "uglifyjs dist/milsymbol.development.js -o dist/milsymbol.js --compress --mangle --source-map",
-    "test":
-      "mocha --compilers js:babel-core/register test/.setup.js --recursive test "
+    "minify": "uglifyjs dist/milsymbol.development.js -o dist/milsymbol.js --compress --mangle --source-map",
+    "test": "mocha -r @std/esm test/.setup.js --recursive test "
   },
   "repository": {
     "type": "git",
@@ -29,6 +27,7 @@
   },
   "homepage": "https://github.com/spatialillusions/milsymbol",
   "devDependencies": {
+    "@std/esm": "^0.18.0",
     "chai": "^4.1.0",
     "eslint": "^4.2.0",
     "eslint-plugin-prettier": "^2.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,3 @@
-//import resolve from "rollup-plugin-node-resolve";
-//import commonjs from "rollup-plugin-commonjs";
-
 export default {
   input: "src/index.js",
   output: {
@@ -10,9 +7,5 @@ export default {
       id: "milsymbol"
     }
   },
-  //freeze: false,
-  name: "ms",
-  plugins: [
-    /*resolve(), commonjs()*/
-  ]
+  name: "ms"
 };

--- a/test/ms.spec.js
+++ b/test/ms.spec.js
@@ -1,5 +1,5 @@
-const { assert } = require("chai");
-const ms = require("../src/index");
+import { assert } from "chai";
+import ms from "../src/index";
 
 describe("ms", () => {
   const publicApiMethods = {

--- a/test/sample-symbol-svgs.js
+++ b/test/sample-symbol-svgs.js
@@ -1,7 +1,7 @@
 const friendlyGroundUnitSvg =
   '<svg xmlns="http://www.w3.org/2000/svg" version="1.2" baseProfile="tiny" width="63.2" height="43.2" viewBox="21 46 158 108"><path d="M25,50 l150,0 0,100 -150,0 z" stroke-width="4" stroke="black" fill="rgb(128,224,255)" fill-opacity="1"></path></svg>';
 
-module.exports = {
+export default {
   // A few different SIDC formats that should all produce the same very basic test symbol
   SFG: friendlyGroundUnitSvg,
   "SFG-": friendlyGroundUnitSvg,

--- a/test/symbol.spec.js
+++ b/test/symbol.spec.js
@@ -1,6 +1,6 @@
-const { assert, expect } = require("chai");
-const ms = require("../src/index");
-const sampleSymbolSvgs = require("./sample-symbol-svgs");
+import { assert, expect } from "chai";
+import ms from "../src/index";
+import sampleSymbolSvgs from "./sample-symbol-svgs";
 
 describe("ms.Symbol", () => {
   // TODO: pass options


### PR DESCRIPTION
Using [`@std/esm`](https://github.com/standard-things/esm) instead of [Babel](https://babeljs.io) for now since `import`/`export` are the only ES6 features being used.

In the future, consider moving the tests to [Jest](https://facebook.github.io/jest) which is easier to add ES6 features to and might eliminate the need for `.setup.js`.