### PR TITLE
Missing 'sidc' field from options in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,7 @@ type SymbolOptions = {
   platformType?: string;
   quantity?: string;
   reinforcedReduced?: string;
+  sidc?:string;
   sigint?: string;
   signatureEquipment?: string;
   simpleStatusModifier?: boolean;


### PR DESCRIPTION
The `sidc` field is missing from the `SymbolOptions` object in the TypeScript types.
Needed for example in the return value from `Symbol.getOptions()`.