### PR TITLE
Add missing function getVersion in TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -124,3 +124,6 @@ export class Symbol {
   setOptions(opts: SymbolOptions): Symbol;
   toDataURL(): string;
 }
+
+// Gets the version of milsymbol.
+export function getVersion(): string;


### PR DESCRIPTION
Global function `ms.getVersion()` is missing from TypeScript typings