### PR TITLE
fix using cyrillic in amplifier fields

### DIFF
--- a/src/ms/symbol.js
+++ b/src/ms/symbol.js
@@ -122,7 +122,9 @@ import setOptions from "./symbol/setoptions.js";
 Symbol.prototype.setOptions = setOptions;
 
 Symbol.prototype.toDataURL = function() {
-      return "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(this.asSVG())));
+  return (
+    "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(this.asSVG())))
+  );
 };
 
 export default Symbol;

--- a/src/ms/symbol.js
+++ b/src/ms/symbol.js
@@ -122,7 +122,7 @@ import setOptions from "./symbol/setoptions.js";
 Symbol.prototype.setOptions = setOptions;
 
 Symbol.prototype.toDataURL = function() {
-      "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(this.asSVG())))
+      return "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(this.asSVG())));
 };
 
 export default Symbol;

--- a/src/ms/symbol.js
+++ b/src/ms/symbol.js
@@ -122,7 +122,7 @@ import setOptions from "./symbol/setoptions.js";
 Symbol.prototype.setOptions = setOptions;
 
 Symbol.prototype.toDataURL = function() {
-  return "data:image/svg+xml;base64," + window.btoa(this.asSVG());
+      "data:image/svg+xml;base64," + window.btoa(unescape(encodeURIComponent(this.asSVG())))
 };
 
 export default Symbol;


### PR DESCRIPTION
Replace window.btoa(this.asSVG()) to window.btoa(unescape(encodeURIComponent(this.asSVG())))
Issue:
https://github.com/spatialillusions/milsymbol/issues/234