### PR TITLE
fix typescript typings for constructor to allow any number of arguments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -108,8 +108,7 @@ type SymbolColors = {
 export class Symbol {
   constructor(
     code: string | SymbolOptions,
-    opts?: SymbolOptions,
-    style?: SymbolOptions
+    ...options: SymbolOptions[]
   );
 
   asCanvas(factor?: number): HTMLCanvasElement;


### PR DESCRIPTION
the code for Symbol constructor allows for any number of options arguments.
Fix typescript typings to reflect that.