### PR TITLE
Updating the typescript types for the results of getColors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -232,13 +232,13 @@ Gets the colors used for this symbol.
 
 ```javascript
 Object {
-  black: String, // Black parts of the symbol.
-  fillColor: String, // Symbol fill color.
-  frameColor: String, // Symbol frame color.
-  iconColor: String, // Icon color.
-  iconFillColor: String, // Icon fill color.
-  none: String, // Transparent parts of the symbol.
-  white: String // White parts of the symbol.
+  black: ColorMode, // Black parts of the symbol.
+  fillColor: ColorMode, // Symbol fill color.
+  frameColor: ColorMode, // Symbol frame color.
+  iconColor: ColorMode, // Icon color.
+  iconFillColor: ColorMode, // Icon fill color.
+  none: ColorMode, // Transparent parts of the symbol.
+  white: ColorMode // White parts of the symbol.
 }
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,13 +96,13 @@ type SymbolMetadata = {
 };
 
 type SymbolColors = {
-  black: string; // Black parts of the symbol.
-  fillColor: string; // Symbol fill color.
-  frameColor: string; // Symbol frame color.
-  iconColor: string; // Icon color.
-  iconFillColor: string; // Icon fill color.
-  none: string; // Transparent parts of the symbol.
-  white: string; // White parts of the symbol.
+  black: ColorMode; // Black parts of the symbol.
+  fillColor: ColorMode; // Symbol fill color.
+  frameColor: ColorMode; // Symbol frame color.
+  iconColor: ColorMode; // Icon color.
+  iconFillColor: ColorMode; // Icon fill color.
+  none: ColorMode; // Transparent parts of the symbol.
+  white: ColorMode; // White parts of the symbol.
 };
 
 export class Symbol {


### PR DESCRIPTION
Updating the typescript types for the results of getColors to show that it returns `ColorMode` objects and not strings.