### PR TITLE
fix radio relay line

### DIFF
--- a/src/iconparts/ground.js
+++ b/src/iconparts/ground.js
@@ -537,7 +537,7 @@ export default function(
     {
       type: "path",
       fill: false,
-      d: "M100,120 l-15,-40 15,0 0,-20 M70,60 l60,0"
+      d: "M100,120 l0,-60 M70,60 l60,0"
     }
   ];
   icn["GR.IC.RADIO TELETYPE CENTRE"] = [

--- a/src/numbersidc/sidc/landunit.js
+++ b/src/numbersidc/sidc/landunit.js
@@ -495,25 +495,9 @@ export default {
       sIdm1["77"] = [icn["GR.M1.SUPPORT"]];
       sIdm1["78"] = [icn["GR.M1.AVIATION"]];
       sIdm1["79"] = [icn["GR.M1.ROUTE, RECONNAISSANCE, AND CLEARANCE"]];
-      sIdm1["80"] = [icn["GR.M1.TILT-ROTOR"]];
-      sIdm1["81"] = [icn["GR.M1.COMMAND POST NODE"]];
-      sIdm1["82"] = [icn["GR.M1.JOINT NETWORK NODE"]];
-      sIdm1["83"] = [icn["GR.M1.RETRANSMISSION SITE"]];
-      sIdm1["84"] = [icn["GR.M1.ASSAULT"]];
-
-      sIdm1["85"] = [icn["GR.M1.WEAPONS"]];
-      sIdm1["86"] = [icn["GR.M1.CRIMINAL INVESTIGATION DIVISION"]];
-      sIdm1["87"] = [icn["GR.M1.DIGITAL"]];
-      sIdm1["88"] = [icn["GR.M1.NETWORK OR NETWORK OPERATIONS"]];
-      sIdm1["89"] = [
-        icn[
-          "GR.M1.AIRFIELD, AERIAL PORT OF DEBARKATION, OR AERIAL PORT OF EMBARKATION"
-        ]
-      ];
-      sIdm1["90"] = [icn["GR.M1.PIPELINE"]];
-      sIdm1["91"] = [icn["GR.M1.POSTAL"]];
-      sIdm1["92"] = [icn["GR.M1.WATER"]];
-      sIdm1["93"] = [icn["GR.M1.INDEPENDENT COMMAND"]];
+      sIdm1["80"] = [icn["GR.M1.COMMAND POST NODE"]];
+      sIdm1["81"] = [icn["GR.M1.JOINT NETWORK NODE"]];
+      sIdm1["82"] = [icn["GR.M1.RETRANSMISSION SITE"]];
 
       sIdm1["94"] = [icn["GR.M1.THEATRE"]];
       sIdm1["95"] = [icn["GR.M1.ARMY"]];


### PR DESCRIPTION
Hello,

the Symbol for the Radio Relay is not correct. According to the standard it should look like this:

![Screenshot from 2023-05-23 14-25-19](https://github.com/spatialillusions/milsymbol/assets/134394046/185252a9-f6e3-4655-91aa-f5fa96dbbb65)


Example APP6-D Code: 10031000001108000000

The current version draws the symbol like this:

![Screenshot from 2023-05-23 14-28-00](https://github.com/spatialillusions/milsymbol/assets/134394046/22e18b16-fade-4bb5-8f9e-8115b7b0185e)

I just fixed the line to be straight. So that it will now look like this:

![Screenshot from 2023-05-23 14-29-13](https://github.com/spatialillusions/milsymbol/assets/134394046/30b855a6-5280-4a32-b0ec-181f07152dd2)