### PR TITLE
Fixed an invalid value for textanchor by changing it from "left" to "start"

### DIFF
--- a/src/iconparts/tactical-points.js
+++ b/src/iconparts/tactical-points.js
@@ -2949,7 +2949,7 @@ export default function(
       ? {
           type: "text",
           stroke: false,
-          textanchor: "left",
+          textanchor: "start",
           x: 120,
           y: 110,
           fontsize: 35,


### PR DESCRIPTION
text-anchor can only have one of the 3 values "start", "middle", "end"
Documentation is [here](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/text-anchor)
This issue was causing an exception in the SVG renderer I am using.