### PR TITLE
Add TypeScript typings for `addIconParts`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -286,6 +286,7 @@ type DrawText = {
   stroke: string | false;
   strokedasharray?: string;
   strokewidth?: number;
+  text: string;
 };
 
 type DrawSVG = {
@@ -334,6 +335,15 @@ export type ExtensionFunction = (
 
 export function addSymbolPart(extension: ExtensionFunction): typeof _default;
 
+export type IconPartsFunction = (
+  this: Symbol,
+  iconParts: Record<string, DrawInstruction | DrawInstruction[]>,
+  metadata: SymbolMetadata,
+  colors: SymbolColors
+) => void;
+
+export function addIconParts(iconParts: IconPartsFunction);
+
 declare const _default: {
   Symbol: typeof Symbol;
   BBox: BBoxConstructor;
@@ -347,6 +357,7 @@ declare const _default: {
   getVersion: typeof getVersion;
   setStandard: typeof setStandard;
   addSymbolPart: typeof addSymbolPart;
+  addIconParts: typeof addIconParts;
 };
 
 export default _default;

--- a/index.d.ts
+++ b/index.d.ts
@@ -342,7 +342,7 @@ export type IconPartsFunction = (
   colors: SymbolColors
 ) => void;
 
-export function addIconParts(iconParts: IconPartsFunction);
+export function addIconParts(iconParts: IconPartsFunction): typeof _default;
 
 declare const _default: {
   Symbol: typeof Symbol;


### PR DESCRIPTION
Hi!

Small addition : `addIconParts` was missing its TypeScript declaration in `index.d.ts`.

This PR adds:
- the `IconPartsFunction` type describing the callback signature (`iconParts`, `metadata`, `colors`)
- the declaration for `addIconParts` itself
- its export in the default object type
- a missing `text` field on `DrawText` spotted along the way

Nothing groundbreaking, just making sure TypeScript users get proper autocompletion and type checking when using `addIconParts`.
