### PR TITLE
 Add Node-side PNG export for Symbol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ docs/milstandard.js
 
 docs/svg-icons-2525D
 docs/svg-icons-2525E
+
+# Unity package embedding metadata
+*.meta

--- a/index.d.ts
+++ b/index.d.ts
@@ -181,6 +181,7 @@ export class Symbol {
   asCanvas(factor?: number): HTMLCanvasElement;
   asDOM(): Element;
   asOffscreenCanvas(factor?: number): OffscreenCanvas;
+  asPNG(options?: { width?: number; height?: number }): Promise<Uint8Array>;
   asSVG(): string;
   getAnchor(): { x: number; y: number };
   getColors(): SymbolColors;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "milsymbol",
       "version": "3.0.4",
       "license": "MIT",
+      "dependencies": {
+        "@resvg/resvg-js": "^2.6.2"
+      },
       "devDependencies": {
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.1.8",
@@ -282,6 +285,233 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "url": "https://github.com/spatialillusions/milsymbol/issues"
   },
   "homepage": "https://github.com/spatialillusions/milsymbol",
+  "dependencies": {
+    "@resvg/resvg-js": "^2.6.2"
+  },
   "devDependencies": {
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.1.8",

--- a/src/ms/symbol.js
+++ b/src/ms/symbol.js
@@ -99,6 +99,9 @@ Symbol.prototype.asDOM = function () {
 import asSVG from "./symbol/assvg.js";
 Symbol.prototype.asSVG = asSVG;
 
+import asPNG from "./symbol/aspng.js";
+Symbol.prototype.asPNG = asPNG;
+
 Symbol.prototype.getAnchor = function () {
   return this.symbolAnchor;
 };

--- a/src/ms/symbol/aspng.js
+++ b/src/ms/symbol/aspng.js
@@ -1,0 +1,36 @@
+function sizedSvg(svg, width, height) {
+  const outputWidth = Math.max(1, Number(width) || 1);
+  const outputHeight = Math.max(1, Number(height) || 1);
+
+  return svg.replace(/<svg\b([^>]*)>/i, (match, attrs) => {
+    let nextAttrs = attrs;
+    if (/\swidth=/i.test(nextAttrs)) {
+      nextAttrs = nextAttrs.replace(/\swidth=(["'])[^"']*\1/i, ` width="${outputWidth}"`);
+    } else {
+      nextAttrs += ` width="${outputWidth}"`;
+    }
+
+    if (/\sheight=/i.test(nextAttrs)) {
+      nextAttrs = nextAttrs.replace(/\sheight=(["'])[^"']*\1/i, ` height="${outputHeight}"`);
+    } else {
+      nextAttrs += ` height="${outputHeight}"`;
+    }
+
+    return `<svg${nextAttrs}>`;
+  });
+}
+
+export default async function asPNG(options = {}) {
+  const { Resvg } = await import("@resvg/resvg-js");
+  const width = Number.isFinite(options.width) ? options.width : this.width;
+  const height = Number.isFinite(options.height) ? options.height : this.height;
+  const svg = sizedSvg(this.asSVG(), width, height);
+  const renderer = new Resvg(svg, {
+    fitTo: {
+      mode: "original"
+    },
+    background: "rgba(0, 0, 0, 0)"
+  });
+
+  return renderer.render().asPng();
+}


### PR DESCRIPTION
## Summary

  This PR adds an async `Symbol.asPNG()` API for Node.js usage.

  The new API renders the existing SVG output through `@resvg/resvg-js` and returns a PNG `Uint8Array`. This makes it
  possible to generate raster symbol assets directly from milsymbol in Node-based tooling without requiring a browser
  canvas or a separate SVG conversion step.

  ## Changes

  - Add `src/ms/symbol/aspng.js`
    - Uses `this.asSVG()` as the source of truth.
    - Supports optional `{ width, height }`.
    - Preserves transparent background output.
    - Returns PNG bytes as `Uint8Array`.

  - Register the API on `Symbol.prototype`
    - `symbol.asPNG(options)`

  - Add TypeScript declaration
    - `asPNG(options?: { width?: number; height?: number }): Promise<Uint8Array>`

  - Add production dependency
    - `@resvg/resvg-js`

  - Ignore Unity `.meta` files
    - Useful when milsymbol is embedded in Unity package workflows.

  ## Example

  ```js
  import ms from "./index.js";

  const symbol = new ms.Symbol("SFAPMFQ----B---", {
    size: 100,
    infoFields: false
  });

  const png = await symbol.asPNG({
    width: 256,
    height: 256
  });
```

  ## Why

  Some editor/build pipelines need PNG files instead of SVG, especially Unity tooling where SVG support is not available
  by default. Exposing PNG export directly from milsymbol keeps the SVG generation path unchanged while allowing Node
  tools to produce raster assets reliably.

  ## Validation

  Tested locally with:

  node --input-type=module -e "import ms from './index.js'; const s = new ms.Symbol('SFAPMFQ----B---', { size: 100,
  infoFields: false }); const png = await s.asPNG({ width: 256, height: 256 }); console.log({ valid: s.isValid(), bytes:
  png.length, header: Array.from(png.slice(0, 8)) });"

  Result:

  {
    valid: true,
    bytes: 5814,
    header: [137, 80, 78, 71, 13, 10, 26, 10]
  }

  Also checked production dependency audit:

  npm audit --omit=dev --audit-level=high

  Result:

  found 0 vulnerabilities

  ## Notes

  This API is intended for Node.js environments. Browser rendering paths such as asCanvas(), asOffscreenCanvas(), and
  asSVG() are unchanged.