### PR TITLE
fix: correct feintDummy typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -264,7 +264,7 @@ Object {
   dimensionUnknown: Boolean, // Is the dimension unknown
   echelon: String, //What echelon (Platoon/Company...)
   faker: Boolean, // Is it a Faker
-  fenintDummy: Boolean, // Is it a feint/dummy
+  feintDummy: Boolean, // Is it a feint/dummy
   fill: Boolean, // Standard says it should be filled
   frame: Boolean, // Standard says it should be framed
   functionid: String, // Part of SIDC referring to the icon.

--- a/index.d.ts
+++ b/index.d.ts
@@ -148,7 +148,7 @@ export type SymbolMetadata = {
   dismounted?: boolean; // Land Dismounted Individual should have special icons
   echelon: Echelon; //What echelon (Platoon/Company...)
   faker: boolean; // Is it a Faker
-  fenintDummy: boolean; // Is it a feint/dummy
+  feintDummy: boolean; // Is it a feint/dummy
   fill: boolean; // Standard says it should be filled
   frame: boolean; // Standard says it should be framed
   functionid: string; // Part of SIDC referring to the icon.

--- a/src/ms/symbol/getmetadata.js
+++ b/src/ms/symbol/getmetadata.js
@@ -13,7 +13,7 @@ export default function getMetadata() {
     dimensionUnknown: false, //Is the dimension unknown
     echelon: "", //What echelon (Platoon/Company...)
     faker: false, //Is it a Faker
-    fenintDummy: false, //Is it a feint/dummy
+    feintDummy: false, //Is it a feint/dummy
     fill: this.style.fill, //Standard says it should be filled
     frame: this.style.frame, //Standard says it should be framed
     functionid: "", //Part of SIDC referring to the icon.


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct the misspelled `fenintDummy` field to `feintDummy` in the metadata defaults, TypeScript definition, and generated docs.

Fixes #345

## Test plan
- static validation: `fenintDummy` appeared 1 time(s) in `src/ms/symbol/getmetadata.js` before replacement.
- static validation: `feintDummy` is present in `src/ms/symbol/getmetadata.js` after patch.
- static validation: `fenintDummy` is absent from `src/ms/symbol/getmetadata.js` after patch.
- static validation: `fenintDummy` appeared 1 time(s) in `index.d.ts` before replacement.
- static validation: `feintDummy` is present in `index.d.ts` after patch.
- static validation: `fenintDummy` is absent from `index.d.ts` after patch.
- static validation: `fenintDummy` appeared 1 time(s) in `docs/README.md` before replacement.
- static validation: `feintDummy` is present in `docs/README.md` after patch.
- static validation: `fenintDummy` is absent from `docs/README.md` after patch.
- Not run: runtime test suite, because this is a documentation/typo-focused fix validated by static text checks.
