### PR TITLE
+ Mission Tasks Occupy 341700

### DIFF
--- a/src/iconparts/tactical-points.js
+++ b/src/iconparts/tactical-points.js
@@ -123,6 +123,30 @@ export default function (
             text: "N",
           },
         ];
+  icn["TP.OCCUPY"] =
+    [
+          {
+            type: "path",
+            fill: false,
+            d: "M0,50 A50,50 0 0,1 96.98,32.89 M96.98,67.1 A50,50 0 0,1 9.04,78.67",
+          },
+          {
+            type: "path",
+            fill: false,
+            d: "M9.04,78.67 l15,5 M9.04,78.67 l-11.18,11.18 M9.04,78.67 l11.18,-11.18 M9.04,78.67 l-15,-5"
+          },
+
+          {
+            type: "text",
+            alignmentBaseline: "middle",
+            stroke: false,
+            textanchor: "middle",
+            x: 96,
+            y: 53,
+            fontsize: 26,
+            text: "O",
+          }
+        ];
   icn["TP.SUPPRESS"] =
     !STD2525 && !numberSIDC
       ? [

--- a/src/lettersidc/labels/tactical-points-2525.js
+++ b/src/lettersidc/labels/tactical-points-2525.js
@@ -4,6 +4,7 @@ export default function tacticalPoints(sidc) {
   sidc["G-T-D-----"] = {}; //TACGRP.TSK.DSTY
   sidc["G-T-I-----"] = {}; //TACGRP.TSK.ITDT
   sidc["G-T-N-----"] = {}; //TACGRP.TSK.NEUT
+  sidc["G-T-O-----"] = {}; //TACGRP.TSK.OCCP
   sidc["G-G-GPUUD-"] = {}; //TACGRP.C2GM.GNL.PNT.USW.UH2.DTM
   sidc["G-G-GPUUB-"] = {}; //TACGRP.C2GM.GNL.PNT.USW.UH2.BCON
   sidc["G-G-GPUUL-"] = {}; //TACGRP.C2GM.GNL.PNT.USW.UH2.LCON

--- a/src/lettersidc/labels/tactical-points-app6.js
+++ b/src/lettersidc/labels/tactical-points-app6.js
@@ -4,6 +4,7 @@ export default function tacticalPoints(sidc) {
   sidc["G-T-GD----"] = {}; //2.X.1.1.9 DESTROY
   sidc["G-T-GI----"] = {}; //2.X.1.1.13 INTERDICT
   sidc["G-T-GN----"] = {}; //2.X.1.1.15 NEUTRALIZE
+  sidc["G-T-GO----"] = {}; //2.X.1.1.17 OCCUPY
   sidc["G-C-MGPFE-"] = {}; //2.X.2.1.1.1.1.1 ELECTRO-MAGNETIC
   sidc["G-C-MGPFA-"] = {}; //2.X.2.1.1.1.1.2 ACOUSTIC
   sidc["G-C-MGPFO-"] = {}; //2.X.2.1.1.1.1.3 ELECTRO-OPTICAL

--- a/src/lettersidc/sidc/tactical-points-2525.js
+++ b/src/lettersidc/sidc/tactical-points-2525.js
@@ -17,6 +17,8 @@ export default {
     bbox["G-T-I-----"] = { x1: 0, x2: 200, y1: 40, y2: 160 };
     sidc["G-T-N-----"] = icn["TP.NEUTRALIZE"]; //TACGRP.TSK.NEUT
     bbox["G-T-N-----"] = { x1: 0, x2: 200, y1: 40, y2: 160 };
+    sidc["G-T-O-----"] = icn["TP.OCCUPY"]; //TACGRP.TSK.OCCP
+    bbox["G-T-O-----"] = { x1: -2, x2: 102, y1: 0, y2: 100 };
     sidc["G-G-GPUUD-"] = icn["TP.DATUM"]; //TACGRP.C2GM.GNL.PNT.USW.UH2.DTM
     bbox["G-G-GPUUD-"] = { x1: 50, x2: 150, y1: 50, y2: 150 };
     sidc["G-G-GPUUB-"] = icn["TP.BRIEF CONTACT"]; //TACGRP.C2GM.GNL.PNT.USW.UH2.BCON

--- a/src/lettersidc/sidc/tactical-points-app6.js
+++ b/src/lettersidc/sidc/tactical-points-app6.js
@@ -17,6 +17,8 @@ export default {
     bbox["G-T-GI----"] = { x1: 0, x2: 200, y1: 40, y2: 160 };
     sidc["G-T-GN----"] = icn["TP.NEUTRALIZE"]; //2.X.1.1.15
     bbox["G-T-GN----"] = { x1: 0, x2: 200, y1: 40, y2: 160 };
+    sidc["G-T-GO----"] = icn["TP.OCCUPY"]; //2.X.1.1.17
+    bbox["G-T-GO----"] = { x1: -2, x2: 102, y1: 0, y2: 100 };
     sidc["G-C-MGPFE-"] = icn["TP.FIX ELECTRO-MAGNETIC"]; //2.X.2.1.1.1.1.2
     sidc["G-C-MGPFA-"] = icn["TP.FIX ACOUSTIC"]; //2.X.2.1.1.1.1.2
     sidc["G-C-MGPFO-"] = icn["TP.FIX ELECTRO-OPTICAL"]; //2.X.2.1.1.1.1.3

--- a/src/numbersidc/labels/tactical-points.js
+++ b/src/numbersidc/labels/tactical-points.js
@@ -1076,6 +1076,7 @@ export default function tacticalPoints(sidc) {
   sidc["340900"] = {}; //Mission Tasks / Destroy
   sidc["341400"] = {}; //Mission Tasks / Interdict
   sidc["341600"] = {}; //Mission Tasks / Neutralize
+  sidc["341700"] = {}; //Mission Tasks / Occupy
   sidc["342800"] = {};
   sidc["350101"] = {};
   sidc["350102"] = {};

--- a/src/numbersidc/sidc/control-measure.js
+++ b/src/numbersidc/sidc/control-measure.js
@@ -523,6 +523,8 @@ export default {
       bbox["341400"] = { x1: 0, x2: 200, y1: 40, y2: 160 };
       sidc["341600"] = icn["TP.NEUTRALIZE"]; //Mission Tasks / Neutralize
       bbox["341600"] = { x1: 0, x2: 200, y1: 40, y2: 160 };
+      sidc["341700"] = icn["TP.OCCUPY"]; //Mission Tasks / Occupy
+      bbox["341700"] = { x1: -2, x2: 102, y1: 0, y2: 100 };
       sidc["342800"] = icn["TP.SUPPRESS"];
       bbox["342800"] = { x1: 0, x2: 200, y1: 40, y2: 160 };
       //sidc["350000"] = []; // N/A


### PR DESCRIPTION
I recently noticed that a few mission task icons are missing. I tried adding one just to test it out (Mission Tasks 341700 Occupy). I hope the way I did it is acceptable and every thing is correct; if not, please let me know whats wrong and how or if I can add missing icons at all.